### PR TITLE
Support ESM exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elm-css-modules-plugin",
   "description": "Babel plugin for use within cultureamp/elm-css-modules-loader",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "repository": "git@github.com:cultureamp/elm-css-modules-plugin.git",
   "author": "Louis Quinnell <zioroboco@gmail.com>",
   "license": "MIT",

--- a/test/fixtures/simple-output-esm.js
+++ b/test/fixtures/simple-output-esm.js
@@ -1,0 +1,4 @@
+var author$project$Styles$styles = A2(author$project$CssModules$css, "./Main.css", {
+  aC: require("./Main.css").default["something"],
+  aD: require("./Main.css").default["somethingElse"]
+});

--- a/test/plugin.spec.ts
+++ b/test/plugin.spec.ts
@@ -9,12 +9,15 @@ const EXAMPLE_TAGGER_NAME = "author$project$CssModules$css"
 const fixture = (filename: string) =>
   fs.readFileSync(path.join(__dirname, "fixtures", filename)).toString()
 
-const transformWith = (plugin: ({}) => PluginObj, options?: PluginOptions) => (
-  input: string
-) => transformSync(input, { plugins: [[plugin, options]] }).code
+const transformWith =
+  (plugin: ({}) => PluginObj, options?: PluginOptions) => (input: string) =>
+    transformSync(input, { plugins: [[plugin, options]] }).code
 
 describe("elm-css-modules-plugin", () => {
-  const transform = transformWith(plugin, { taggerName: EXAMPLE_TAGGER_NAME })
+  const transform = transformWith(plugin, {
+    taggerName: EXAMPLE_TAGGER_NAME,
+    expectCssModulesToBeEsModule: false,
+  })
 
   it("transforms simple input to the expected output", () => {
     const input = fixture("simple-input.js")
@@ -50,9 +53,19 @@ describe("elm-css-modules-plugin", () => {
   it("locates and transforms modules by tagger name according to snapshot", () => {
     const alternateTaggerName = "someone$elsewhere$BizarroCssModules$bcss"
     const alternateTransform = transformWith(plugin, {
-      taggerName: alternateTaggerName
+      taggerName: alternateTaggerName,
     })
     const input = fixture("alternate-tagger.js")
     expect(alternateTransform(input)).toMatchSnapshot()
+  })
+
+  it("uses the default export if expectEsModule is false", () => {
+    const alternateTransform = transformWith(plugin, {
+      taggerName: EXAMPLE_TAGGER_NAME,
+      expectCssModulesToBeEsModule: true,
+    })
+    const input = fixture("simple-input.js")
+    const expectedOutput = fixture("simple-output-esm.js")
+    expect(alternateTransform(input)).toBe(expectedOutput)
   })
 })


### PR DESCRIPTION
Context:
The Webpack 5 upgrade seems to cause css-loader to expect esm exports.

Solution:
Added a config option called `expectCssModulesToBeEsModule` which defaults to false. Setting this to true will add 
`require('file').default['stylename']` default.